### PR TITLE
fix: PkmFileEntity key conflict errors

### DIFF
--- a/PKVault.Backend/db/loader/PkmFileLoader.cs
+++ b/PKVault.Backend/db/loader/PkmFileLoader.cs
@@ -116,30 +116,38 @@ public class PkmFileLoader : IPkmFileLoader
             : [];
         var error = pkm.LoadError;
 
-        var entity = new PkmFileEntity()
-        {
-            Filepath = filepath,
-            Data = data,
-            Error = error,
-            Updated = updated,
-            Deleted = false
-        };
-
-        await AttachEntity(entity);
+        var entity = await GetAttachedEntity(filepath);
+        
+        entity.Data = data;
+        entity.Error = error;
+        entity.Updated = updated;
+        entity.Deleted = false;
 
         return entity;
     }
 
-    private async Task AttachEntity(PkmFileEntity entity)
+    private async Task<PkmFileEntity> GetAttachedEntity(string filepath)
     {
         var dbSet = await GetDbSet();
 
-        var exists = await dbSet.AnyAsync(e => e.Filepath == entity.Filepath);
+        var existing = await dbSet.FindAsync(filepath);
+        if (existing != null)
+            return existing;
 
-        db.PkmFiles.Attach(entity);
-        db.Entry(entity).State = exists
-            ? EntityState.Modified
-            : EntityState.Added;
+        var newEntity = new PkmFileEntity()
+        {
+            Filepath = filepath,
+            // default values
+            Data = [],
+            Error = null,
+            Updated = false,
+            Deleted = false,
+        };
+
+        db.PkmFiles.Attach(newEntity);
+        db.Entry(newEntity).State = EntityState.Added;
+
+        return newEntity;
     }
 
     public async Task WriteToFiles()


### PR DESCRIPTION
Fix error throwing from this reproduce steps:


Given these actions:

- Move: (pkm) main -> save
- Move attached: (same pkm) save -> main
- Evolve: (same pkm) save
- Remove action: Evolve

Triggers this kind of error:
```
System.InvalidOperationException:
The instance of entity type 'PkmFileEntity' cannot be tracked because another instance with the key value '{Filepath: ./tmp/storage/foobar.xk3}' is already being tracked.
When attaching existing entities, ensure that only one entity instance with a given key value is attached.
```