### PR TITLE
fix: pokedex empty when no save

### DIFF
--- a/PKVault.Backend/dex/services/DexService.cs
+++ b/PKVault.Backend/dex/services/DexService.cs
@@ -12,11 +12,6 @@ public class DexService(
     {
         var saveLoaders = savesLoadersService.GetAllLoaders();
 
-        if (saveLoaders.Length == 0)
-        {
-            return [];
-        }
-
         return await GetDex([FakeSaveFile.Default.ID32, .. saveLoaders.Select(sl => sl.Save.Id)], speciesSet);
     }
 


### PR DESCRIPTION
fix #186 