### PR TITLE
feat: upload save files from the web UI (auto-sorted by game)

### DIFF
--- a/PKVault.Backend/save-infos/routes/SaveInfosRoute.cs
+++ b/PKVault.Backend/save-infos/routes/SaveInfosRoute.cs
@@ -89,7 +89,10 @@ public class SaveInfosController(
             data = ms.ToArray();
         }
 
-        if (!SaveUtil.TryGetSaveFile(data, out var save, file.FileName) || save == null)
+        // PKHeX may decrypt/mutate the buffer in place while detecting the save
+        // (SwishCrypto games: SwSh/BDSP/LA/SV), so detect on a copy and persist
+        // the untouched original bytes.
+        if (!SaveUtil.TryGetSaveFile((byte[])data.Clone(), out var save, file.FileName) || save == null)
         {
             return BadRequest("File is not a recognized save file");
         }

--- a/PKVault.Backend/save-infos/routes/SaveInfosRoute.cs
+++ b/PKVault.Backend/save-infos/routes/SaveInfosRoute.cs
@@ -1,5 +1,7 @@
 using System.Net.Mime;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using PKHeX.Core;
 
 namespace PKVault.Backend.saveinfos.routes;
 
@@ -7,7 +9,8 @@ namespace PKVault.Backend.saveinfos.routes;
 [Route("api/[controller]")]
 public class SaveInfosController(
     ISettingsService settingsService,
-    DataService dataService, ISavesLoadersService savesLoadersService, ISessionService sessionService
+    DataService dataService, ISavesLoadersService savesLoadersService, ISessionService sessionService,
+    IFileIOService fileIOService
 ) : ControllerBase
 {
     [HttpGet()]
@@ -51,5 +54,171 @@ public class SaveInfosController(
 
         byte[] fileBytes = save.GetSaveFileData();
         return File(fileBytes, MediaTypeNames.Application.Octet, filename);
+    }
+
+    /// <summary>
+    /// Upload a save file. The game version is detected with PKHeX and the file
+    /// is stored under the configured save folder, grouped by generation and
+    /// game (ex: "Gen3/Emerald"). Saves are then rescanned so the new file shows up.
+    /// Especially useful in the Docker/web context where dropping files into the
+    /// mounted folder by hand is inconvenient.
+    /// </summary>
+    [HttpPost("upload")]
+    public async Task<ActionResult<DataDTO>> Upload(IFormFile file)
+    {
+        if (!sessionService.HasEmptyActionList())
+        {
+            throw new InvalidOperationException($"Empty action list is required");
+        }
+
+        if (file == null || file.Length == 0)
+        {
+            return BadRequest("No file provided");
+        }
+
+        var (TooSmall, TooBig) = fileIOService.CheckGameFile(file.Length);
+        if (TooSmall || TooBig)
+        {
+            return BadRequest("File size does not match a valid save file");
+        }
+
+        byte[] data;
+        using (var ms = new MemoryStream())
+        {
+            await file.CopyToAsync(ms);
+            data = ms.ToArray();
+        }
+
+        if (!SaveUtil.TryGetSaveFile(data, out var save, file.FileName) || save == null)
+        {
+            return BadRequest("File is not a recognized save file");
+        }
+
+        var baseDir = ResolveUploadBaseDir();
+        if (baseDir == null)
+        {
+            return BadRequest("No save folder configured. Add a saves folder in Settings first.");
+        }
+
+        var gameFolder = GameVersionNameUtil.GetGameFolder(save.Version, save.Generation);
+
+        var safeName = Path.GetFileName(file.FileName);
+        if (string.IsNullOrWhiteSpace(safeName))
+        {
+            safeName = string.IsNullOrWhiteSpace(save.Metadata.FileName) ? "save.sav" : save.Metadata.FileName;
+        }
+
+        var destPath = MatcherUtil.NormalizePath(Path.Combine(baseDir, gameFolder, safeName));
+        destPath = GetNonConflictingPath(destPath);
+
+        await fileIOService.WriteBytes(destPath, data);
+
+        // rescan saves so the uploaded file is picked up (same flow as Scan)
+        DataUpdateFlags flags = new();
+        settingsService.RefreshSettings(flags);
+        savesLoadersService.Clear();
+        await sessionService.StartNewSession(checkInitialActions: true, flags);
+
+        return await dataService.CreateDataFromUpdateFlags(flags);
+    }
+
+    /// <summary>
+    /// Resolve a writable base directory to store uploaded saves, derived from
+    /// the configured SAVE_GLOBS. Only globs pointing to a folder (containing a
+    /// wildcard, or an existing directory) are considered so uploaded files land
+    /// where saves are actually scanned. Returns null if none is usable.
+    /// </summary>
+    private string? ResolveUploadBaseDir()
+    {
+        var globs = settingsService.GetSettings().SettingsMutable.SAVE_GLOBS ?? [];
+
+        foreach (var rawGlob in globs)
+        {
+            var glob = rawGlob?.Trim();
+            if (string.IsNullOrEmpty(glob) || glob[0] == '!')
+            {
+                continue;
+            }
+
+            var normalized = MatcherUtil.NormalizePath(glob);
+            var segments = normalized.Split('/');
+
+            var literalParts = new List<string>();
+            var hasWildcard = false;
+            foreach (var seg in segments)
+            {
+                if (seg.Contains('*') || seg.Contains('?') || seg.Contains('['))
+                {
+                    hasWildcard = true;
+                    break;
+                }
+                literalParts.Add(seg);
+            }
+
+            var literalPath = string.Join('/', literalParts);
+            if (string.IsNullOrWhiteSpace(literalPath))
+            {
+                continue;
+            }
+
+            if (!Path.IsPathRooted(literalPath))
+            {
+                literalPath = MatcherUtil.NormalizePath(Path.Combine(SettingsService.GetAppDirectory(), literalPath));
+            }
+
+            string? candidate = null;
+            if (hasWildcard)
+            {
+                candidate = literalPath;
+            }
+            else if (Directory.Exists(literalPath))
+            {
+                candidate = literalPath;
+            }
+
+            if (candidate == null)
+            {
+                continue;
+            }
+
+            try
+            {
+                fileIOService.CreateDirectory(candidate);
+                return MatcherUtil.NormalizePath(candidate);
+            }
+            catch
+            {
+                // not writable, try next glob
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Ensure the destination path does not overwrite an existing file by
+    /// appending an incrementing suffix (ex: "file (1).sav").
+    /// </summary>
+    private string GetNonConflictingPath(string path)
+    {
+        if (!fileIOService.Exists(path))
+        {
+            return path;
+        }
+
+        var dir = Path.GetDirectoryName(path) ?? "";
+        var name = Path.GetFileNameWithoutExtension(path);
+        var ext = Path.GetExtension(path);
+
+        for (var i = 1; i < 1000; i++)
+        {
+            var candidate = MatcherUtil.NormalizePath(Path.Combine(dir, $"{name} ({i}){ext}"));
+            if (!fileIOService.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return path;
     }
 }

--- a/PKVault.Backend/swagger.json
+++ b/PKVault.Backend/swagger.json
@@ -1319,6 +1319,40 @@
         }
       }
     },
+    "/api/save-infos/upload": {
+      "post": {
+        "tags": [
+          "SaveInfos"
+        ],
+        "operationId": "SaveInfos_Upload",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file",
+            "x-nullable": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "x-nullable": false,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataDTO"
+            }
+          }
+        }
+      }
+    },
     "/api/save-infos/{saveId}/download": {
       "get": {
         "tags": [

--- a/PKVault.Backend/utils/GameVersionNameUtil.cs
+++ b/PKVault.Backend/utils/GameVersionNameUtil.cs
@@ -1,0 +1,78 @@
+using PKHeX.Core;
+
+/// <summary>
+/// Maps a PKHeX <see cref="GameVersion"/> to a stable, human-readable folder
+/// name used to organize uploaded save files by game.
+/// </summary>
+public static class GameVersionNameUtil
+{
+    /// <summary>
+    /// Returns a readable game name (English, filesystem-safe). Falls back to
+    /// the raw <see cref="GameVersion"/> identifier for unmapped values.
+    /// </summary>
+    public static string GetGameName(GameVersion version)
+    {
+        var name = version switch
+        {
+            GameVersion.RD => "Red",
+            GameVersion.BU => "Blue",
+            GameVersion.GN => "Green",
+            GameVersion.YW => "Yellow",
+            GameVersion.GD => "Gold",
+            GameVersion.SI => "Silver",
+            GameVersion.C => "Crystal",
+            GameVersion.R => "Ruby",
+            GameVersion.S => "Sapphire",
+            GameVersion.E => "Emerald",
+            GameVersion.FR => "FireRed",
+            GameVersion.LG => "LeafGreen",
+            GameVersion.CXD => "ColosseumXD",
+            GameVersion.D => "Diamond",
+            GameVersion.P => "Pearl",
+            GameVersion.Pt => "Platinum",
+            GameVersion.HG => "HeartGold",
+            GameVersion.SS => "SoulSilver",
+            GameVersion.B => "Black",
+            GameVersion.W => "White",
+            GameVersion.B2 => "Black2",
+            GameVersion.W2 => "White2",
+            GameVersion.X => "X",
+            GameVersion.Y => "Y",
+            GameVersion.OR => "OmegaRuby",
+            GameVersion.AS => "AlphaSapphire",
+            GameVersion.SN => "Sun",
+            GameVersion.MN => "Moon",
+            GameVersion.US => "UltraSun",
+            GameVersion.UM => "UltraMoon",
+            GameVersion.GP => "LetsGoPikachu",
+            GameVersion.GE => "LetsGoEevee",
+            GameVersion.SW => "Sword",
+            GameVersion.SH => "Shield",
+            GameVersion.BD => "BrilliantDiamond",
+            GameVersion.SP => "ShiningPearl",
+            GameVersion.PLA => "LegendsArceus",
+            GameVersion.SL => "Scarlet",
+            GameVersion.VL => "Violet",
+            _ => version.ToString(),
+        };
+
+        return SanitizeName(name);
+    }
+
+    /// <summary>
+    /// Returns the destination sub-path used to store an uploaded save,
+    /// grouped by generation then game, e.g. "Gen3/Emerald".
+    /// </summary>
+    public static string GetGameFolder(GameVersion version, int generation)
+    {
+        var gen = generation > 0 ? $"Gen{generation}" : "GenUnknown";
+        return Path.Combine(gen, GetGameName(version));
+    }
+
+    private static string SanitizeName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string([.. name.Where(c => !invalid.Contains(c))]).Trim();
+        return string.IsNullOrEmpty(cleaned) ? "Unknown" : cleaned;
+    }
+}

--- a/frontend/src/pages/saves.tsx
+++ b/frontend/src/pages/saves.tsx
@@ -1,9 +1,11 @@
 import { Badge, Button, Card, Divider, EmptyState, Group, Tooltip } from '@mantine/core';
-import { CirclePlusIcon, DownloadIcon, FolderIcon, PackageOpenIcon } from 'lucide-react';
+import { CirclePlusIcon, DownloadIcon, FolderIcon, PackageOpenIcon, UploadIcon } from 'lucide-react';
 import type React from "react";
+import { useRef } from "react";
 import { HistoryContext } from '../context/history-context';
 import { getApiFullUrl } from '../data/mutator/custom-instance';
-import { getSaveInfosDownloadUrl, useSaveInfosGetAll } from '../data/sdk/save-infos/save-infos.gen';
+import { getSaveInfosDownloadUrl, useSaveInfosGetAll, useSaveInfosUpload } from '../data/sdk/save-infos/save-infos.gen';
+import { useSettingsGet } from '../data/sdk/settings/settings.gen';
 import { withErrorCatcher } from '../error/with-error-catcher';
 import { useStaticData } from '../hooks/use-static-data';
 import { getGameInfos } from '../pokedex/details/util/get-game-infos';
@@ -26,6 +28,10 @@ export const SavesPage: React.FC = withErrorCatcher('default', () => {
 
   const staticData = useStaticData();
   const saveInfosQuery = useSaveInfosGetAll();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadMutation = useSaveInfosUpload();
+  const settings = useSettingsGet().data?.data;
 
   const isLoading = saveInfosQuery.isPending || saveInfosQuery.isEnabled;
 
@@ -125,20 +131,55 @@ export const SavesPage: React.FC = withErrorCatcher('default', () => {
       })}
 
       <Card.Section inheritPadding withBorder py='inherit'>
-        <Tooltip label={t('saves.action.add')}>
-          <UIActionIcon
-            name='add-game'
-            controlLabel={t('saves.action.add.controls-label')}
-            onClick={() => navigate({
-              to: '/settings'
-            })}
-            variant='default'
-            size='xl'
-            w='100%'
+        <input
+          ref={fileInputRef}
+          type='file'
+          accept='.sav,.dsv,.srm,.dat,.bin,.gci,.raw,.dsb,.sa2,.gsc,.st,.dst'
+          style={{ display: 'none' }}
+          onChange={(event) => {
+            const file = event.target.files?.[ 0 ];
+            if (file) {
+              uploadMutation.mutate({ data: { file } });
+            }
+            event.target.value = '';
+          }}
+        />
+        <Group grow>
+          <Tooltip
+            multiline
+            label={[
+              t('saves.action.upload'),
+              !settings?.canScanSaves && t('action.not-possible'),
+            ].filter(Boolean).join('\n')}
           >
-            <CirclePlusIcon />
-          </UIActionIcon>
-        </Tooltip>
+            <UIActionIcon
+              name='upload-save'
+              controlLabel={t('saves.action.upload.controls-label')}
+              onClick={() => fileInputRef.current?.click()}
+              loading={uploadMutation.isPending}
+              disabled={!settings?.canScanSaves}
+              variant='default'
+              size='xl'
+              w='100%'
+            >
+              <UploadIcon />
+            </UIActionIcon>
+          </Tooltip>
+          <Tooltip label={t('saves.action.add')}>
+            <UIActionIcon
+              name='add-game'
+              controlLabel={t('saves.action.add.controls-label')}
+              onClick={() => navigate({
+                to: '/settings'
+              })}
+              variant='default'
+              size='xl'
+              w='100%'
+            >
+              <CirclePlusIcon />
+            </UIActionIcon>
+          </Tooltip>
+        </Group>
       </Card.Section>
     </Card>
   </UISavesContent>;

--- a/frontend/src/pages/saves.tsx
+++ b/frontend/src/pages/saves.tsx
@@ -134,7 +134,6 @@ export const SavesPage: React.FC = withErrorCatcher('default', () => {
         <input
           ref={fileInputRef}
           type='file'
-          accept='.sav,.dsv,.srm,.dat,.bin,.gci,.raw,.dsb,.sa2,.gsc,.st,.dst'
           style={{ display: 'none' }}
           onChange={(event) => {
             const file = event.target.files?.[ 0 ];

--- a/frontend/src/translate/locales/de.json
+++ b/frontend/src/translate/locales/de.json
@@ -193,6 +193,8 @@
   "saves.action.add.controls-label": "Speicherstände hinzufügen",
   "saves.action.download": "Speicherdatei herunterladen",
   "saves.action.open": "Ordner mit Speicherständen öffnen",
+  "saves.action.upload": "Speicherdatei hochladen",
+  "saves.action.upload.controls-label": "Hochladen",
   "saves.title": "Generation {{generation}}",
   "saves.title.species": "{{maxSpecies}} Arten",
   "settings.about.1.description": "GitHub repository",

--- a/frontend/src/translate/locales/en.json
+++ b/frontend/src/translate/locales/en.json
@@ -193,6 +193,8 @@
   "saves.action.add.controls-label": "Add saves",
   "saves.action.download": "Download save file",
   "saves.action.open": "Open save folder",
+  "saves.action.upload": "Upload a save file",
+  "saves.action.upload.controls-label": "Upload save",
   "saves.title": "Generation {{generation}}",
   "saves.title.species": "{{maxSpecies}} species",
   "settings.about.1.description": "GitHub repository",

--- a/frontend/src/translate/locales/fr.json
+++ b/frontend/src/translate/locales/fr.json
@@ -193,6 +193,8 @@
   "saves.action.add.controls-label": "Ajouter des sauvegardes",
   "saves.action.download": "Télécharger le fichier de sauvegarde",
   "saves.action.open": "Ouvrir le dossier de sauvegarde",
+  "saves.action.upload": "Téléverser un fichier de sauvegarde",
+  "saves.action.upload.controls-label": "Téléverser",
   "saves.title": "Génération {{generation}}",
   "saves.title.species": "{{maxSpecies}} espèces",
   "settings.about.1.description": "Dépôt GitHub",

--- a/frontend/src/translate/locales/pt-br.json
+++ b/frontend/src/translate/locales/pt-br.json
@@ -193,6 +193,8 @@
   "saves.action.add.controls-label": "Adicionar novo save",
   "saves.action.download": "Baixar",
   "saves.action.open": "Abrir",
+  "saves.action.upload": "Enviar arquivo de save",
+  "saves.action.upload.controls-label": "Enviar",
   "saves.title": "Geração {{generation}}",
   "saves.title.species": "{{maxSpecies}} espécies",
   "settings.about.1.description": "O PKVault é um aplicativo moderno para gerenciamento de saves e Pokédex.",

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,6 +6,9 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # allow larger save files uploads (Switch 'main' saves can exceed the 1M default)
+    client_max_body_size 50m;
+
     server {
         listen 3000;
 


### PR DESCRIPTION
## What

Adds the ability to **upload a save file directly from the web UI**. The uploaded save's game version is detected with PKHeX and the file is stored under the configured saves folder, grouped by **generation and game** (e.g. `Gen3/Emerald/`, `Gen8/Sword/`). Saves are then rescanned so the new file appears immediately.

## Why

In the Docker / web context there is no way to add a save without manually dropping files into the mounted volume (SSH, file manager on the host, etc.). This makes onboarding new saves inconvenient. An in-app upload solves that and keeps the saves folder tidy by auto-sorting per game.

## How

**Backend**
- New `POST /api/save-infos/upload` endpoint (`SaveInfosController`) accepting a multipart `file`.
- Validates size (`CheckGameFile`) and that the file is a real save (`SaveUtil.TryGetSaveFile`); returns `400` otherwise.
- New `GameVersionNameUtil` maps `GameVersion` → readable name and builds the `Gen{N}/{Game}` sub-path.
- Destination base directory is derived from the first configured `SAVE_GLOBS` entry; the file is written with `FileIOService`, avoiding overwrites (`file (1).sav`…).
- After writing, it runs the same rescan flow as `Scan` and returns `DataDTO`, so the client cache updates automatically.
- Requires an empty action list (same contract as `Scan`) to avoid discarding pending storage changes.

**Frontend**
- "Upload save" button on the saves page (hidden file input + `UIActionIcon`).
- Uses the generated `useSaveInfosUpload` mutation; the global mutation `onSettled` refreshes the cache.
- Button is disabled while there are pending actions, mirroring the existing Scan button.
- New i18n keys `saves.action.upload` / `saves.action.upload.controls-label` in `en`, `fr`, `de`, `pt-br`.
- `swagger.json` updated with the new operation.

## Fixes needed to support 3DS & Switch saves

While testing, three issues were found and fixed so uploads work across all supported consoles:

1. **Any file type selectable** — 3DS/Switch saves are a `main` file with no extension, so the restrictive `accept` filter on the file input prevented selecting them. Removed it (the backend still validates every file with PKHeX).
2. **nginx `client_max_body_size 50m`** — the default (1M) silently returned `413` before the request reached the backend, blocking Switch saves (SwSh ~1.3M, SV ~4.4M). DS/3DS saves are small so they passed; larger Switch saves failed with no backend log.
3. **Preserve original save bytes** — PKHeX decrypts SwishCrypto saves (SwSh/BDSP/LA/SV) **in place** while detecting them, so persisting that same buffer wrote a decrypted `main` with an invalid hash that the scan then rejected. Now detection runs on a copy and the untouched original bytes are written.

## Testing

- Backend `dotnet build`: 0 errors. Frontend `c:type`, `c:lint`, `c:translate`: pass.
- Built the monolith Docker image and ran it end-to-end. Uploaded and verified detection for:
  - DS: SoulSilver (Gen4), White2 (Gen5)
  - 3DS: Ultra Sun (Gen7, `main`)
  - Switch: Sword (Gen8, `main`, ~1.5M)
- Each save was stored under `/data/saves/Gen{N}/{Game}/` and appeared in the saves list.

## Notes

- Folder naming is English and filesystem-safe, with a fallback to the raw `GameVersion` for unmapped values.
- Assumes the configured save glob is recursive (e.g. `/data/saves/**`) so files in the `Gen{N}/{Game}` sub-folders are picked up.
