### PR TITLE
fix: savefile id conflicts

### DIFF
--- a/PKVault.Backend.Tests/db/loader/save/SavePkmLoaderTests.cs
+++ b/PKVault.Backend.Tests/db/loader/save/SavePkmLoaderTests.cs
@@ -90,7 +90,6 @@ public class SavePkmLoaderTests : IAsyncLifetime
 
         Assert.Equal(3, dto.BoxId);
         Assert.Equal(15, dto.BoxSlot);
-        Assert.Equal((uint)100, dto.SaveId);
         Assert.Equal(25, dto.Species);
         Assert.Equal(3, dto.Generation);
         Assert.Equal("TEST", dto.Nickname);

--- a/PKVault.Backend/dex/services/gen/DexGenService.cs
+++ b/PKVault.Backend/dex/services/gen/DexGenService.cs
@@ -50,7 +50,7 @@ public abstract class DexGenService(SaveFile save) //where Save : SaveFile
                 arr = [];
                 dex.Add(species, arr);
             }
-            arr[save.ID32] = item;
+            arr[new SaveWrapper(save).Id] = item;
         }
 
         // logtime();
@@ -125,13 +125,13 @@ public abstract class DexGenService(SaveFile save) //where Save : SaveFile
         return new DexItemDTO(
             Id: GetDexItemID(species),
             Species: species,
-            SaveId: save.ID32,
+            SaveId: new SaveWrapper(save).Id,
             Forms: forms,
             Languages: [.. languages]
         );
     }
 
-    protected string GetDexItemID(ushort species) => $"{species}_{save.ID32}";
+    protected string GetDexItemID(ushort species) => $"{species}_{new SaveWrapper(save).Id}";
 
     public List<byte> GetTypes(PersonalInfo pi) => GetTypes(save.Generation, pi);
 

--- a/PKVault.Backend/settings/services/SettingsService.cs
+++ b/PKVault.Backend/settings/services/SettingsService.cs
@@ -7,6 +7,7 @@ using Serilog;
 public interface ISettingsService
 {
     public Task UpdateSettings(SettingsMutableDTO settingsMutable, bool restartSession, bool scanSaves, DataUpdateFlags flags);
+    public Task UpdateSettingsSimple(SettingsMutableDTO settingsMutable, string userId);
     public Task<SettingsDTO> GetSettingsWithUserId();
     public SettingsDTO GetSettings();
     public SettingsDTO RefreshSettings(DataUpdateFlags flags);
@@ -34,23 +35,14 @@ public class SettingsService(IServiceProvider sp) : ISettingsService
 
     public async Task UpdateSettings(SettingsMutableDTO settingsMutable, bool restartSession, bool scanSaves, DataUpdateFlags flags)
     {
-        await fileIOService.WriteJSONFile(
-            FilePath,
-            SettingsMutableDTOJsonContext.Default.SettingsMutableDTO,
-            settingsMutable
-        );
-        flags.Settings = true;
-
         using var scope = sp.CreateScope();
 
         var userId = string.IsNullOrEmpty(BaseSettings?.UserId)
             ? await scope.ServiceProvider.GetRequiredService<IMetaLoader>().GetUserId()
             : BaseSettings.UserId;
 
-        BaseSettings = ReadBaseSettings() with
-        {
-            UserId = userId
-        };
+        await UpdateSettingsSimple(settingsMutable, userId);
+        flags.Settings = true;
 
         if (restartSession)
         {
@@ -66,6 +58,20 @@ public class SettingsService(IServiceProvider sp) : ISettingsService
         {
             await savesLoadersService.Setup(flags);
         }
+    }
+
+    public async Task UpdateSettingsSimple(SettingsMutableDTO settingsMutable, string userId)
+    {
+        await fileIOService.WriteJSONFile(
+            FilePath,
+            SettingsMutableDTOJsonContext.Default.SettingsMutableDTO,
+            settingsMutable
+        );
+
+        BaseSettings = ReadBaseSettings() with
+        {
+            UserId = userId
+        };
     }
 
     /**

--- a/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
+++ b/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
@@ -111,7 +111,7 @@ public class DataNormalizeAction(
         {
             await MigrateVariantsFrom200(input);
         }
-        else if (GetVersionValue(currentVersion.Value) <= GetVersionValue("2.2.1"))
+        else if (GetVersionValue(currentVersion.Value) <= GetVersionValue("2.3.0"))
         {
             await MigrateIdsTo221();
         }
@@ -476,6 +476,7 @@ public class DataNormalizeAction(
                 else
                 {
                     variant.AttachedSaveId = null;
+                    variant.AttachedSavePkmIdBase = null;
                 }
 
                 await pkmVariantLoader.UpdateEntity(variant);
@@ -484,5 +485,50 @@ public class DataNormalizeAction(
         }
 
         await db.SaveChangesAsync();
+
+        var settings = settingsService.GetSettings();
+        var settingsMutable = settings.SettingsMutable;
+        var settingsChanged = false;
+
+        if (settingsMutable.SAVE_PATH_OVERRIDES != null && settingsMutable.SAVE_PATH_OVERRIDES.Count > 0)
+        {
+            var savePathOverridesCopy = settingsMutable.SAVE_PATH_OVERRIDES.ToDictionary();
+            foreach (var entry in settingsMutable.SAVE_PATH_OVERRIDES)
+            {
+                var loader = allLoaders.FirstOrDefault(l => l?.Save.ID32 == entry.Key, null);
+                if (loader == null)
+                    continue;
+
+                savePathOverridesCopy.Remove(entry.Key);
+                savePathOverridesCopy.TryAdd(loader.Save.Id, entry.Value);
+                settingsChanged = true;
+            }
+
+            settingsMutable = settingsMutable with {
+                SAVE_PATH_OVERRIDES = savePathOverridesCopy
+            };
+        }
+
+        if (settingsMutable.SAVE_VERSION_OVERRIDES != null && settingsMutable.SAVE_VERSION_OVERRIDES.Count > 0)
+        {
+            var saveVersionOverridesCopy = settingsMutable.SAVE_VERSION_OVERRIDES.ToDictionary();
+            foreach (var entry in settingsMutable.SAVE_VERSION_OVERRIDES)
+            {
+                var loader = allLoaders.FirstOrDefault(l => l?.Save.ID32 == entry.Key, null);
+                if (loader == null)
+                    continue;
+
+                saveVersionOverridesCopy.Remove(entry.Key);
+                saveVersionOverridesCopy.TryAdd(loader.Save.Id, entry.Value);
+                settingsChanged = true;
+            }
+
+            settingsMutable = settingsMutable with {
+                SAVE_VERSION_OVERRIDES = saveVersionOverridesCopy
+            };
+        }
+
+        if (settingsChanged)
+            await settingsService.UpdateSettingsSimple(settingsMutable, settings.UserId);
     }
 }

--- a/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
+++ b/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
@@ -111,6 +111,10 @@ public class DataNormalizeAction(
         {
             await MigrateVariantsFrom200(input);
         }
+        else if (GetVersionValue(currentVersion.Value) <= GetVersionValue("2.2.1"))
+        {
+            await MigrateIdsTo221();
+        }
 
         // --- Update version
 
@@ -392,6 +396,93 @@ public class DataNormalizeAction(
 
             return variant;
         }));
+        await db.SaveChangesAsync();
+    }
+
+    private async Task MigrateIdsTo221()
+    {
+        var allLoaders = savesLoadersService.GetAllLoaders();
+        var allVariants = await pkmVariantLoader.GetAllEntities();
+        var allBanks = await bankLoader.GetAllEntities();
+
+        if (allBanks.Count > 0)
+        {
+            foreach (var bank_entity in allBanks.Values)
+            {
+                var boxes = bank_entity.View.MainBoxIds;
+                var oldSaves = bank_entity.View.Saves;
+
+                if (oldSaves.Length == 0)
+                    continue;
+
+                var updatedSaves = new BankEntity.BankViewSave[oldSaves.Length];
+
+                for (int i = 0; i < oldSaves.Length; i++)
+                {
+                    var oldSave = oldSaves[i];
+                    SaveLoadersRecord? matchLoaderBank = null;
+
+                    foreach (var loader in allLoaders)
+                    {
+                        if (loader.Save.ID32 == oldSave.SaveId)
+                        {
+                            matchLoaderBank = loader;
+                            break;
+                        }
+                    }
+
+                    uint SaveId = 0;
+                    if (matchLoaderBank != null)
+                    {
+                        SaveId = matchLoaderBank.Save.Id;
+                    }
+
+                    updatedSaves[i] = new BankEntity.BankViewSave(
+                        SaveId,
+                        oldSave.SaveBoxIds,
+                        oldSave.Order
+                    );
+                }
+
+                bank_entity.View = new(boxes, updatedSaves);
+
+                await bankLoader.UpdateEntity(bank_entity);
+            }
+        }
+        
+        if (allVariants.Count > 0)
+        {
+
+            foreach (var variant in allVariants.Values)
+            {
+                if (variant.AttachedSaveId == null)
+                    continue;
+
+                SaveLoadersRecord? matchLoaderVariants = null;
+
+                foreach (var loader in allLoaders)
+                {
+                    if (loader.Save.ID32 == variant.AttachedSaveId)
+                    {
+                        matchLoaderVariants = loader;
+                        break;
+                    }
+                }
+
+                if (matchLoaderVariants != null)
+                {
+                    variant.AttachedSaveId = matchLoaderVariants.Save.Id;
+                }
+                else
+                {
+                    variant.AttachedSaveId = null;
+                }
+
+                await pkmVariantLoader.UpdateEntity(variant);
+            }
+            
+        }
+
         await db.SaveChangesAsync();
     }
 }

--- a/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
+++ b/PKVault.Backend/storage/data-action/DataNormalizeAction.cs
@@ -113,7 +113,7 @@ public class DataNormalizeAction(
         }
         else if (GetVersionValue(currentVersion.Value) <= GetVersionValue("2.3.0"))
         {
-            await MigrateIdsTo221();
+            await MigrateIdsTo230();
         }
 
         // --- Update version
@@ -399,7 +399,7 @@ public class DataNormalizeAction(
         await db.SaveChangesAsync();
     }
 
-    private async Task MigrateIdsTo221()
+    private async Task MigrateIdsTo230()
     {
         var allLoaders = savesLoadersService.GetAllLoaders();
         var allVariants = await pkmVariantLoader.GetAllEntities();

--- a/PKVault.Backend/storage/wrapper/SaveWrapper.cs
+++ b/PKVault.Backend/storage/wrapper/SaveWrapper.cs
@@ -23,7 +23,13 @@ public class SaveWrapper(SaveFile Save)
                 byte[] hash = SHA1.HashData(bytes);
                 return BitConverter.ToUInt32(hash, 0);
             }
-            return Save.ID32;
+
+            string rawKey = $"{Save.Version}-{Save.Language}-{Save.ID32}-{Save.OT}-{Save.Gender}";
+
+            byte[] inputBytes = Encoding.UTF8.GetBytes(rawKey);
+            byte[] hashBytes = SHA256.HashData(inputBytes);
+
+            return BitConverter.ToUInt32(hashBytes, 0);
         }
     }
 

--- a/PKVault.Backend/storage/wrapper/SaveWrapper.cs
+++ b/PKVault.Backend/storage/wrapper/SaveWrapper.cs
@@ -13,6 +13,22 @@ public class SaveWrapper(SaveFile Save)
     {
         get
         {
+            string rawKey = $"{(byte)Save.Version}-{Save.Language}-{ID32}-{Save.OT}-{(byte)Save.Gender}";
+
+            byte[] inputBytes = Encoding.UTF8.GetBytes(rawKey);
+            byte[] hashBytes = SHA256.HashData(inputBytes);
+
+            return BitConverter.ToUInt32(hashBytes, 0);
+        }
+    }
+
+    public uint ID32
+    {
+        get
+        {
+            if (Save == FakeSaveFile.Default)
+                return FakeSaveFile.Default.ID32;
+
             if (Save.ID32 == default)
             {
                 // var encodeBase = $"{(byte)Save.Version}-{Save.Generation}-{Save.TID16}-{Save.Metadata.FilePath}";
@@ -23,17 +39,9 @@ public class SaveWrapper(SaveFile Save)
                 byte[] hash = SHA1.HashData(bytes);
                 return BitConverter.ToUInt32(hash, 0);
             }
-
-            string rawKey = $"{(byte)Save.Version}-{Save.Language}-{Save.ID32}-{Save.OT}-{(byte)Save.Gender}";
-
-            byte[] inputBytes = Encoding.UTF8.GetBytes(rawKey);
-            byte[] hashBytes = SHA256.HashData(inputBytes);
-
-            return BitConverter.ToUInt32(hashBytes, 0);
+            return Save.ID32;
         }
     }
-
-    public uint ID32 => Save.ID32;
 
     public SaveFileState State => Save.State;
     public SaveFileMetadata Metadata => Save.Metadata;

--- a/PKVault.Backend/storage/wrapper/SaveWrapper.cs
+++ b/PKVault.Backend/storage/wrapper/SaveWrapper.cs
@@ -24,7 +24,7 @@ public class SaveWrapper(SaveFile Save)
                 return BitConverter.ToUInt32(hash, 0);
             }
 
-            string rawKey = $"{Save.Version}-{Save.Language}-{Save.ID32}-{Save.OT}-{Save.Gender}";
+            string rawKey = $"{(byte)Save.Version}-{Save.Language}-{Save.ID32}-{Save.OT}-{(byte)Save.Gender}";
 
             byte[] inputBytes = Encoding.UTF8.GetBytes(rawKey);
             byte[] hashBytes = SHA256.HashData(inputBytes);
@@ -32,6 +32,8 @@ public class SaveWrapper(SaveFile Save)
             return BitConverter.ToUInt32(hashBytes, 0);
         }
     }
+
+    public uint ID32 => Save.ID32;
 
     public SaveFileState State => Save.State;
     public SaveFileMetadata Metadata => Save.Metadata;


### PR DESCRIPTION
Issue #230 

Since the save file ID was previously generated using only ID32 and is now calculated using a combination of multiple parameters (Version, Language, ID32, OT, and Gender), attached Pokémon  have lost their connection to their counterparts in save files, causing errors.

Please let me know if any changes or adjustments are needed!

<img width="473" height="258" alt="image" src="https://github.com/user-attachments/assets/4fc80c36-74b1-4243-93d1-1c02eba8a822" />
