### PR TITLE
fix: pkm sync ignoring saves where a baby pokémon evolved

### DIFF
--- a/PKVault.Core.Tests/static-data/services/utils/EvolveUtilTests.cs
+++ b/PKVault.Core.Tests/static-data/services/utils/EvolveUtilTests.cs
@@ -1,0 +1,44 @@
+using PKHeX.Core;
+using PKVault.Core;
+
+/**
+ * GetBaseSpecies is already covered indirectly by ImmutablePKMTests.
+ */
+public class EvolveUtilTests : IAsyncLifetime
+{
+    private StaticEvolvesData evolves;
+
+    public async ValueTask InitializeAsync()
+    {
+        evolves = await StaticEvolvesLoader.LoadData();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    [Theory]
+    // issue #238: baby dex number
+    [InlineData(Species.Magby, Species.Magmar)]
+    // multi-hop chain
+    [InlineData(Species.Pichu, Species.Raichu)]
+    // regular evolution
+    [InlineData(Species.Charmander, Species.Charizard)]
+    // unchanged species
+    [InlineData(Species.Garchomp, Species.Garchomp)]
+    public void IsSameOrDescendantOf_AllowsForwardEvolution(Species ancestor, Species species)
+    {
+        Assert.True(EvolveUtil.IsSameOrDescendantOf(evolves, (ushort)ancestor, (ushort)species));
+    }
+
+    [Theory]
+    // devolution
+    [InlineData(Species.Magmar, Species.Magby)]
+    // unrelated species
+    [InlineData(Species.Magby, Species.Snorlax)]
+    public void IsSameOrDescendantOf_RejectsDevolutionAndUnrelatedSpecies(Species ancestor, Species species)
+    {
+        Assert.False(EvolveUtil.IsSameOrDescendantOf(evolves, (ushort)ancestor, (ushort)species));
+    }
+}

--- a/PKVault.Core/static-data/services/utils/EvolveUtil.cs
+++ b/PKVault.Core/static-data/services/utils/EvolveUtil.cs
@@ -1,0 +1,56 @@
+using PKHeX.Core;
+
+namespace PKVault.Core;
+
+/**
+ * Helpers to walk an evolution chain using StaticEvolvesData.
+ */
+public static class EvolveUtil
+{
+    /**
+     * Walk PreviousSpecies up to the root of the evolution chain.
+     * Note: Shedinja is created from Ninjask exact same data, so it's treated as its own root.
+     */
+    public static ushort GetBaseSpecies(Dictionary<ushort, StaticEvolve> evolves, ushort species)
+    {
+        if (species == 0
+            || species == (ushort)PKHeX.Core.Species.Shedinja
+        )
+        {
+            return species;
+        }
+
+        var previousSpecies = evolves[species].PreviousSpecies;
+        if (previousSpecies != null)
+        {
+            return GetBaseSpecies(evolves, (ushort)previousSpecies);
+        }
+        return species;
+    }
+
+    /**
+     * True if species is ancestor itself, or a descendant of it through the evolution chain.
+     */
+    public static bool IsSameOrDescendantOf(Dictionary<ushort, StaticEvolve> evolves, ushort ancestor, ushort species)
+    {
+        if (species == ancestor)
+        {
+            return true;
+        }
+
+        if (species == 0
+            || species == (ushort)PKHeX.Core.Species.Shedinja
+        )
+        {
+            return false;
+        }
+
+        var previousSpecies = evolves[species].PreviousSpecies;
+        if (previousSpecies == null)
+        {
+            return false;
+        }
+
+        return IsSameOrDescendantOf(evolves, ancestor, (ushort)previousSpecies);
+    }
+}

--- a/PKVault.Core/storage/data-action/SynchronizePkmAction.cs
+++ b/PKVault.Core/storage/data-action/SynchronizePkmAction.cs
@@ -8,6 +8,7 @@ public record SynchronizePkmActionInput(
 );
 
 public class SynchronizePkmAction(
+    StaticDataService staticDataService,
     IPkmSharePropertiesService pkmSharePropertiesService,
     IPkmVariantLoader pkmVariantLoader, ISavesLoadersService savesLoadersService
 ) : DataAction<SynchronizePkmActionInput>
@@ -79,6 +80,8 @@ public class SynchronizePkmAction(
             throw new ArgumentException($"Pkm main & pkm save ids cannot be empty");
         }
 
+        var evolves = await staticDataService.GetStaticEvolves();
+
         async Task act(string pkmVariantId, string savePkmIdBase)
         {
             Log.Information($"Synchronize save->variant {savePkmIdBase} -> {pkmVariantId}");
@@ -116,11 +119,11 @@ public class SynchronizePkmAction(
                     && version.Context == variantPkm.Context
                 );
 
-                var correctSpeciesForm = savePkm.Pkm.Species >= variantPkm.Species
+                var correctSpeciesForm = EvolveUtil.IsSameOrDescendantOf(evolves, variantPkm.Species, savePkm.Pkm.Species)
                     && versions.Any(version => BlankSaveFile.Get(version).Personal.IsPresentInGame(savePkm.Pkm.Species, savePkm.Pkm.Form));
                 if (!correctSpeciesForm)
                 {
-                    Log.Debug($"!correctSpeciesForm => {variant.Id} / {savePkm.Pkm.Species} {savePkm.Pkm.Form} / {savePkm.Pkm.Species} {variantPkm.Species}");
+                    Log.Debug($"!correctSpeciesForm => {variant.Id} / save.Species={savePkm.Pkm.Species} save.Form={savePkm.Pkm.Form} / variant.Species={variantPkm.Species}");
                     continue;
                 }
 

--- a/PKVault.Core/storage/wrapper/ImmutablePKM.cs
+++ b/PKVault.Core/storage/wrapper/ImmutablePKM.cs
@@ -295,27 +295,9 @@ public class ImmutablePKM(PKM Pkm, PKMLoadError? loadError = null)
      */
     public string GetPKMIdBase(Dictionary<ushort, StaticEvolve> evolves, int boxId = (int)BoxType.Box)
     {
-        ushort GetBaseSpecies(ushort species)
-        {
-            if (species == 0
-                // specific case with Shedinja which is created with Ninjask exact same data
-                || species == (ushort)PKHeX.Core.Species.Shedinja
-            )
-            {
-                return species;
-            }
-
-            var previousSpecies = evolves[species].PreviousSpecies;
-            if (previousSpecies != null)
-            {
-                return GetBaseSpecies((ushort)previousSpecies);
-            }
-            return species;
-        }
-
         var clone = Update(clone =>
         {
-            clone.Species = GetBaseSpecies(Pkm.Species);
+            clone.Species = EvolveUtil.GetBaseSpecies(evolves, Pkm.Species);
             clone.Form = 0;
             if (GetMutablePkm() is GBPKM gbpkm && clone is GBPKM gbclone)
             {


### PR DESCRIPTION
Fixes #238.

The save-to-vault sync guard compared national dex numbers (`savePkm.Species >= variantPkm.Species`) to reject devolutions. That breaks for every baby Pokémon line, since their evolution has a lower dex number (Magby is No. 240, evolves into Magmar, No. 126; same deal for Pichu, Wynaut, and others). When the check failed, the sync just silently skipped the update for every variant, so both the origin-generation and evolved-generation copies stayed stale in the vault.

Replaced the dex-number comparison with a proper evolution-chain walk (`EvolveUtil.IsSameOrDescendantOf`), which also let me pull out the base-species walk that `ImmutablePKM.GetPKMIdBase` already had inline into the same helper.

Added 6 tests covering the Magby/Magmar case, a multi-hop chain, regular evolution, same-species no-op, and devolution/unrelated-species rejection.
