### PR TITLE
fix: orphaned pkm-file rows reloaded from disk forever after untracking external pkms

### DIFF
--- a/PKVault.Core.Tests/db/loader/PkmVariantLoaderTests.cs
+++ b/PKVault.Core.Tests/db/loader/PkmVariantLoaderTests.cs
@@ -271,6 +271,168 @@ public class PkmVariantLoaderTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task DeleteEntityDBOnly_ShouldKeepPkmFile()
+    {
+        var db = await GetDB();
+        var loader = await CreateLoader(db);
+
+        var pkm = CreateTestPkm();
+
+        var evolves = await StaticEvolvesLoader.LoadData();
+
+        var idBase = pkm.GetPKMIdBase(evolves);
+        var filepath = $"mock-storage/3/0025 - PIKACHU - {idBase}.pk3";
+
+        await db.Banks
+            .AddAsync(new()
+            {
+                Id = "1",
+                IdInt = 1,
+                IsDefault = true,
+                IsExternal = false,
+                Name = "Bank 1",
+                Order = 0,
+                View = new([], [])
+            }, TestContext.Current.CancellationToken);
+        await db.Boxes
+            .AddAsync(new()
+            {
+                Id = "1",
+                IdInt = 1,
+                Name = "Box 1",
+                Order = 0,
+                Type = BoxType.Box,
+                SlotCount = 30,
+                BankId = "1"
+            }, TestContext.Current.CancellationToken);
+        await db.PkmFiles
+            .AddAsync(new()
+            {
+                Filepath = filepath,
+                Data = [.. pkm.GetDecryptedDataParty()],
+                Error = null,
+                Updated = false,
+                Deleted = false
+            }, TestContext.Current.CancellationToken);
+        await db.PkmVersions
+            .AddAsync(new()
+            {
+                Id = idBase,
+                Hash = idBase,
+                Context = EntityContext.Gen3,
+                Generation = 3,
+                Filepath = filepath,
+                BoxId = "1",
+                BoxSlot = 0,
+                IsMain = true,
+                IsExternal = false,
+                AttachedSaveId = null,
+                AttachedSavePkmIdBase = null,
+
+                Species = 25,
+                Form = 0,
+                Gender = Gender.Female,
+                IsShiny = false,
+                IsAlpha = false,
+
+                PkmFile = null
+            }, TestContext.Current.CancellationToken);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var entity = await db.PkmVersions
+            .Include(p => p.PkmFile)
+            .FirstAsync(p => p.Id == idBase, TestContext.Current.CancellationToken);
+
+        await loader.DeleteEntityDBOnly(entity);
+
+        Assert.Null(await loader.GetEntity(idBase));
+        Assert.NotNull(await db.PkmFiles.FindAsync([filepath], TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteEntityDBOnlyAndUntrackFile_ShouldRemovePkmFile()
+    {
+        var db = await GetDB();
+        var loader = await CreateLoader(db);
+
+        var pkm = CreateTestPkm();
+
+        var evolves = await StaticEvolvesLoader.LoadData();
+
+        var idBase = pkm.GetPKMIdBase(evolves);
+        var filepath = $"mock-storage/3/0025 - PIKACHU - {idBase}.pk3";
+
+        await db.Banks
+            .AddAsync(new()
+            {
+                Id = "1",
+                IdInt = 1,
+                IsDefault = true,
+                IsExternal = true,
+                Name = "External",
+                Order = 0,
+                View = new([], [])
+            }, TestContext.Current.CancellationToken);
+        await db.Boxes
+            .AddAsync(new()
+            {
+                Id = "1",
+                IdInt = 1,
+                Name = "Box 1",
+                Order = 0,
+                Type = BoxType.Box,
+                SlotCount = 30,
+                BankId = "1"
+            }, TestContext.Current.CancellationToken);
+        await db.PkmFiles
+            .AddAsync(new()
+            {
+                Filepath = filepath,
+                Data = [.. pkm.GetDecryptedDataParty()],
+                Error = null,
+                Updated = false,
+                Deleted = false
+            }, TestContext.Current.CancellationToken);
+        await db.PkmVersions
+            .AddAsync(new()
+            {
+                Id = idBase,
+                Hash = idBase,
+                Context = EntityContext.Gen3,
+                Generation = 3,
+                Filepath = filepath,
+                BoxId = "1",
+                BoxSlot = 0,
+                IsMain = true,
+                IsExternal = true,
+                AttachedSaveId = null,
+                AttachedSavePkmIdBase = null,
+
+                Species = 25,
+                Form = 0,
+                Gender = Gender.Female,
+                IsShiny = false,
+                IsAlpha = false,
+
+                PkmFile = null
+            }, TestContext.Current.CancellationToken);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var entity = await db.PkmVersions
+            .Include(p => p.PkmFile)
+            .FirstAsync(p => p.Id == idBase, TestContext.Current.CancellationToken);
+
+        // file on disk must survive
+        await loader.DeleteEntityDBOnlyAndUntrackFile(entity);
+
+        Assert.Null(await loader.GetEntity(idBase));
+        Assert.Null(await db.PkmFiles.FindAsync([filepath], TestContext.Current.CancellationToken));
+        Assert.False(mockFileSystem.File.Exists(filepath));
+    }
+
+    [Fact]
     public async Task GetEntitiesByBox_ShouldReturnAllVersions()
     {
         var db = await GetDB();

--- a/PKVault.Core.Tests/db/services/DbSeedingServiceTests.cs
+++ b/PKVault.Core.Tests/db/services/DbSeedingServiceTests.cs
@@ -1,0 +1,203 @@
+using System.IO.Abstractions.TestingHelpers;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using PKHeX.Core;
+using PKVault.Core;
+
+public class DbSeedingServiceTests : IAsyncDisposable
+{
+    private readonly MockFileSystem mockFileSystem;
+    private readonly IFileIOService fileIOService;
+    private readonly SessionDbContext db;
+    private readonly DbSeedingService dbSeedingService;
+
+    public DbSeedingServiceTests()
+    {
+        var testId = Guid.NewGuid().ToString();
+        var dbPath = $"db-DbSeedingServiceTests-{testId}.db";
+
+        mockFileSystem = new MockFileSystem();
+        fileIOService = new FileIOService(mockFileSystem);
+        fileIOService.Matcher.GetAllPaths = () => [.. mockFileSystem.AllPaths];
+
+        dbSeedingService = new(fileIOService);
+
+        var sessionService = new Mock<ISessionServiceMinimal>();
+        sessionService.Setup(s => s.SessionDbPath).Returns(dbPath);
+
+        db = new(sessionService.Object, dbSeedingService);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await db.Database.EnsureDeletedAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<SessionDbContext> GetDB()
+    {
+        await db.Database.MigrateAsync();
+        return db;
+    }
+
+    // issue #238: orphaned PkmFile rows
+    [Fact]
+    public async Task Seed_ShouldRemoveOrphanedPkmFiles_NotReferencedByAnyVariant()
+    {
+        var db = await GetDB();
+
+        var referencedFilepath = "mock-storage/3/referenced.pk3";
+        var orphanedFilepath = "mock-storage/3/orphaned.pk3";
+
+        mockFileSystem.AddFile(Path.Combine(PathUtils.GetExpectedAppDirectory(), referencedFilepath), new MockFileData([1, 2, 3]));
+        // orphanedFilepath has no backing file
+
+        await db.PkmFiles.AddRangeAsync(
+            [
+                new()
+                {
+                    Filepath = referencedFilepath,
+                    Data = [],
+                    Error = null,
+                    Updated = false,
+                    Deleted = false
+                },
+                new()
+                {
+                    Filepath = orphanedFilepath,
+                    Data = [],
+                    Error = null,
+                    Updated = false,
+                    Deleted = false
+                }
+            ],
+            TestContext.Current.CancellationToken
+        );
+
+        await db.Banks.AddAsync(new()
+        {
+            Id = "1",
+            IdInt = 1,
+            IsDefault = true,
+            IsExternal = false,
+            Name = "Bank 1",
+            Order = 0,
+            View = new([], [])
+        }, TestContext.Current.CancellationToken);
+        await db.Boxes.AddAsync(new()
+        {
+            Id = "1",
+            IdInt = 1,
+            Name = "Box 1",
+            Order = 0,
+            Type = BoxType.Box,
+            SlotCount = 30,
+            BankId = "1"
+        }, TestContext.Current.CancellationToken);
+        await db.PkmVersions.AddAsync(new()
+        {
+            Id = "referenced-variant",
+            Hash = "referenced-variant",
+            Context = EntityContext.Gen3,
+            Generation = 3,
+            Filepath = referencedFilepath,
+            BoxId = "1",
+            BoxSlot = 0,
+            IsMain = true,
+            IsExternal = false,
+            AttachedSaveId = null,
+            AttachedSavePkmIdBase = null,
+
+            Species = 25,
+            Form = 0,
+            Gender = Gender.Female,
+            IsShiny = false,
+            IsAlpha = false,
+
+            PkmFile = null
+        }, TestContext.Current.CancellationToken);
+        // no variant references orphanedFilepath
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        // needed before Seed() re-attaches
+        db.ChangeTracker.Clear();
+
+        await dbSeedingService.Seed(db, false, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await db.PkmFiles.FindAsync([referencedFilepath], TestContext.Current.CancellationToken));
+        Assert.Null(await db.PkmFiles.FindAsync([orphanedFilepath], TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Seed_ShouldStillLoadReferencedPkmFiles()
+    {
+        var db = await GetDB();
+
+        var referencedFilepath = "mock-storage/3/referenced.pk3";
+        byte[] fileBytes = [.. Enumerable.Repeat((byte)7, 64)]; // min pkm size
+
+        mockFileSystem.AddFile(Path.Combine(PathUtils.GetExpectedAppDirectory(), referencedFilepath), new MockFileData(fileBytes));
+
+        await db.PkmFiles.AddAsync(new()
+        {
+            Filepath = referencedFilepath,
+            Data = [],
+            Error = null,
+            Updated = false,
+            Deleted = false
+        }, TestContext.Current.CancellationToken);
+
+        await db.Banks.AddAsync(new()
+        {
+            Id = "1",
+            IdInt = 1,
+            IsDefault = true,
+            IsExternal = false,
+            Name = "Bank 1",
+            Order = 0,
+            View = new([], [])
+        }, TestContext.Current.CancellationToken);
+        await db.Boxes.AddAsync(new()
+        {
+            Id = "1",
+            IdInt = 1,
+            Name = "Box 1",
+            Order = 0,
+            Type = BoxType.Box,
+            SlotCount = 30,
+            BankId = "1"
+        }, TestContext.Current.CancellationToken);
+        await db.PkmVersions.AddAsync(new()
+        {
+            Id = "referenced-variant",
+            Hash = "referenced-variant",
+            Context = EntityContext.Gen3,
+            Generation = 3,
+            Filepath = referencedFilepath,
+            BoxId = "1",
+            BoxSlot = 0,
+            IsMain = true,
+            IsExternal = false,
+            AttachedSaveId = null,
+            AttachedSavePkmIdBase = null,
+
+            Species = 25,
+            Form = 0,
+            Gender = Gender.Female,
+            IsShiny = false,
+            IsAlpha = false,
+
+            PkmFile = null
+        }, TestContext.Current.CancellationToken);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        // needed before Seed() re-attaches
+        db.ChangeTracker.Clear();
+
+        await dbSeedingService.Seed(db, false, TestContext.Current.CancellationToken);
+
+        var pkmFile = await db.PkmFiles.FindAsync([referencedFilepath], TestContext.Current.CancellationToken);
+        Assert.NotNull(pkmFile);
+        Assert.Equal(fileBytes, pkmFile.Data);
+    }
+}

--- a/PKVault.Core/db/loader/PkmVariantLoader.cs
+++ b/PKVault.Core/db/loader/PkmVariantLoader.cs
@@ -30,6 +30,7 @@ public interface IPkmVariantLoader : IEntityLoader<PkmVariantDTO, PkmVariantEnti
     public Task UpdateEntity(PkmVariantEntity entity, BoxDTO? box = null);
     public Task UpdateEntity(PkmVariantEntity entity, ImmutablePKM pkm, BoxDTO? box = null);
     public Task DeleteEntityDBOnly(PkmVariantEntity entity);
+    public Task DeleteEntityDBOnlyAndUntrackFile(PkmVariantEntity entity);
 
     public Task<Dictionary<int, Dictionary<string, PkmVariantEntity>>> GetEntitiesByBox(int boxId);
     public Task<Dictionary<int, Dictionary<string, PkmVariantEntity>>> GetEntitiesByBox(string boxId);
@@ -428,6 +429,19 @@ public class PkmVariantLoader : EntityLoader<PkmVariantDTO, PkmVariantEntity>, I
 
     public async Task DeleteEntityDBOnly(PkmVariantEntity entity)
     {
+        await base.DeleteEntity(entity);
+    }
+
+    /**
+     * Like DeleteEntityDBOnly, but also drops the now-unreferenced PkmFile row.
+     */
+    public async Task DeleteEntityDBOnlyAndUntrackFile(PkmVariantEntity entity)
+    {
+        if (entity.PkmFile != null)
+        {
+            db.PkmFiles.Remove(entity.PkmFile);
+        }
+
         await base.DeleteEntity(entity);
     }
 

--- a/PKVault.Core/db/services/DbSeedingService.cs
+++ b/PKVault.Core/db/services/DbSeedingService.cs
@@ -28,10 +28,30 @@ public class DbSeedingService(IFileIOService fileIOService) : IDbSeedingService
             .AsNoTracking()
             .ToListAsync(cancelToken);
 
+        // drop orphaned PkmFile rows
+        var referencedFilepaths = (await db.Set<PkmVariantEntity>()
+            .AsNoTracking()
+            .Select(variant => variant.Filepath)
+            .ToListAsync(cancelToken))
+            .ToHashSet();
+
+        var orphanedPkmFiles = pkmFiles
+            .Where(pkmFile => !referencedFilepaths.Contains(pkmFile.Filepath))
+            .ToList();
+
+        if (orphanedPkmFiles.Count > 0)
+        {
+            Log.Warning($"Removing {orphanedPkmFiles.Count} orphaned PkmFile DB row(s), no longer referenced by any pkm variant");
+            pkmFilesDb.RemoveRange(orphanedPkmFiles);
+        }
+
+        var pkmFilesToLoad = pkmFiles
+            .Where(pkmFile => referencedFilepaths.Contains(pkmFile.Filepath));
+
         var updatedPkmFiles = new List<PkmFileEntity>(pkmFiles.Count);
         // less performant than Task.WhenAll (1000pkm: 500ms vs 400ms)
         // but avoids CPU spikes
-        foreach (var pkmFile in pkmFiles)
+        foreach (var pkmFile in pkmFilesToLoad)
         {
             updatedPkmFiles.Add(
                 await PkmFileLoader.LoadPkmFile(fileIOService, pkmFile, checkBeforeLoad: false)

--- a/PKVault.Core/storage/data-action/UpdateExternalPkmAction.cs
+++ b/PKVault.Core/storage/data-action/UpdateExternalPkmAction.cs
@@ -288,7 +288,7 @@ public class UpdateExternalPkmAction(
         // careful here to not delete PK files !
         foreach (var pkmVariant in externalPkmsToRemove)
         {
-            await pkmVariantLoader.DeleteEntityDBOnly(pkmVariant);
+            await pkmVariantLoader.DeleteEntityDBOnlyAndUntrackFile(pkmVariant);
         }
 
         var pkmsBoxes = (await boxLoader.GetEntitiesByIds(


### PR DESCRIPTION
Second bug from issue #238 (the reporter's logs kept spamming "Exception during PKM file load" for external PKM paths they'd cleared long ago).

When an external PKM stops matching the External PKMs setting, `UpdateExternalPkmAction` untracks it by deleting its variant row, deliberately without touching the actual file. But the linked file-tracking DB row was never cleaned up either, since it lives in a separate table with no cascade delete. That row becomes a permanent orphan, and `DbSeedingService` reloads every one of those rows from disk on every session start regardless of whether anything still references it, so a stale row for a long-gone path keeps failing and logging a warning forever.

Fix:
- Untracking an external pkm now also drops its file-tracking row (DB row only, file on disk untouched). Kept opt-in on `DeleteEntityDBOnly` because a data-migration path reuses the same row across an entity rename.
- `DbSeedingService` now skips (and deletes) any file row not referenced by any pkm variant before reloading the rest, which is what clears out rows left behind by the bug on existing installs, not just going forward.

Added 4 tests covering both the untracking behavior and the orphan cleanup, plus that normal referenced files still load correctly.
