### PR TITLE
fix: kernell32.dll

### DIFF
--- a/PKVault.Core/router/CoreRouter.cs
+++ b/PKVault.Core/router/CoreRouter.cs
@@ -255,8 +255,9 @@ public partial class CoreRouter
         if (kind == OpenApiParameterKind.Body)
         {
             using var reader = new StreamReader(bodyStream);
-            var body = JsonNode.Parse(reader.ReadToEnd())?.AsObject() ?? [];
-            return body?.Deserialize(p.ParameterType, RouteJsonContext.Default);
+            var jsonText = await reader.ReadToEndAsync();
+            var body = JsonNode.Parse(jsonText)?.AsObject() ?? [];
+            return body?.Deserialize(p.ParameterType, RouteJsonContext.DefaultWithOptions);
         }
 
         throw new ArgumentException($"A {kind} parameter is missing: {p.Name} of type {p.ParameterType} {queries[p.Name!]?.GetType()}");

--- a/PKVault.Desktop/Program.cs
+++ b/PKVault.Desktop/Program.cs
@@ -41,7 +41,10 @@ class Program
     [STAThread]
     static void Main(string[] args)
     {
-        AttachConsole(ATTACH_PARENT_PROCESS);
+        if (WindowsOS)
+        {
+            AttachConsole(ATTACH_PARENT_PROCESS);
+        }
         Core.Program.Initialize();
 
         if (LinuxOS)


### PR DESCRIPTION
When attempting to run the desktop application from source, the following exception occurs:

> Unhandled exception. System.DllNotFoundException: Unable to load shared library 'kernel32.dll' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
$REPO/PKVault/PKVault.Desktop/bin/Debug/net10.0/linux-x64/kernel32.dll.so: cannot open shared object file: No such file or directory
$REPO/PKVault/PKVault.Desktop/bin/Debug/net10.0/linux-x64/libkernel32.dll.so: cannot open shared object file: No such file or directory
$REPO/PKVault/PKVault.Desktop/bin/Debug/net10.0/linux-x64/kernel32.dll: cannot open shared object file: No such file or directory
$REPO/PKVault/PKVault.Desktop/bin/Debug/net10.0/linux-x64/libkernel32.dll: cannot open shared object file: No such file or directory
>
>   at PKVault.Desktop.Program.AttachConsole(UInt32 dwProcessId)
   at PKVault.Desktop.Program.Main(String[] args) in $REPO/PKVault/PKVault.Desktop/Program.cs:line 44

The log indicates that kernel32.dll is required. Since this library is only available on Windows, it prevents the desktop application from running on other operating systems.

Solution: I wrapped the `AttachConsole` P/Invoke call inside `if (WindowsOS)` to ensure Windows-specific Win32 APIs aren't executed on Linux/macOS.